### PR TITLE
Random access always open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 before_script: |
   rustup component add rustfmt-preview
 script: |
+  cargo check --all-targets --verbose &&
   cargo fmt -- --check &&
   cargo build --verbose &&
   cargo test  --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.1"
-random-access-storage = "0.5.0"
+random-access-storage = "0.6.0"
 
 [dev-dependencies]
 quickcheck = "0.6.2"

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -2,8 +2,10 @@
 
 mod sync {
   extern crate random_access_memory as ram;
+  extern crate random_access_storage;
   extern crate test;
 
+  use self::random_access_storage::RandomAccess;
   use self::test::Bencher;
 
   #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub struct RandomAccessMemory;
 
 impl RandomAccessMemory {
   /// Create a new instance.
-  // #[cfg_attr(test, allow(new_ret_no_self))]
+  #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
   pub fn new(page_size: usize) -> RandomAccess<RandomAccessMemoryMethods> {
     let methods = RandomAccessMemoryMethods {
       buffers: Vec::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,74 +8,57 @@ extern crate failure;
 extern crate random_access_storage;
 
 use failure::Error;
-use random_access_storage::{RandomAccess, RandomAccessMethods};
+use random_access_storage::RandomAccess;
 use std::cmp;
+use std::io;
 
 /// Main constructor.
 #[derive(Debug)]
-pub struct RandomAccessMemory;
-
-impl RandomAccessMemory {
-  /// Create a new instance.
-  #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
-  pub fn new(page_size: usize) -> RandomAccess<RandomAccessMemoryMethods> {
-    let methods = RandomAccessMemoryMethods {
-      buffers: Vec::new(),
-      page_size,
-      length: 0,
-    };
-
-    RandomAccess::new(methods)
-  }
-
-  /// Create a new instance with a 1mb page size.
-  // We cannot use the `Default` trait here because we aren't returning `Self`.
-  pub fn default() -> RandomAccess<RandomAccessMemoryMethods> {
-    let methods = RandomAccessMemoryMethods {
-      buffers: Vec::new(),
-      page_size: 1024 * 1024,
-      length: 0,
-    };
-
-    RandomAccess::new(methods)
-  }
-
-  /// Create a new instance, but pass the initial buffers to the constructor.
-  pub fn with_buffers(
-    page_size: usize,
-    buffers: Vec<Vec<u8>>,
-  ) -> RandomAccess<RandomAccessMemoryMethods> {
-    let methods = RandomAccessMemoryMethods {
-      page_size,
-      buffers,
-      length: 0,
-    };
-
-    RandomAccess::new(methods)
-  }
-}
-
-/// Methods that have been implemented to provide synchronous access to memory
-/// buffers. These should generally be kept private, but exposed to prevent
-/// leaking internals.
-#[derive(Debug)]
-pub struct RandomAccessMemoryMethods {
+pub struct RandomAccessMemory {
   /// The length length of each buffer.
-  pub page_size: usize,
+  page_size: usize,
 
   /// The memory we read/write to.
   // TODO: initialize as a sparse vector.
-  pub buffers: Vec<Vec<u8>>,
+  buffers: Vec<Vec<u8>>,
 
   /// Total length of the data.
   length: usize,
 }
 
-impl RandomAccessMethods for RandomAccessMemoryMethods {
-  type Error = Error;
-  fn open(&mut self) -> Result<(), Self::Error> {
-    Ok(())
+impl RandomAccessMemory {
+  /// Create a new instance.
+  #[cfg_attr(feature = "cargo-clippy", allow(new_ret_no_self))]
+  pub fn new(page_size: usize) -> Self {
+    RandomAccessMemory {
+      buffers: Vec::new(),
+      page_size,
+      length: 0,
+    }
   }
+
+  /// Create a new instance with a 1mb page size.
+  // We cannot use the `Default` trait here because we aren't returning `Self`.
+  pub fn default() -> Self {
+    RandomAccessMemory {
+      buffers: Vec::new(),
+      page_size: 1024 * 1024,
+      length: 0,
+    }
+  }
+
+  /// Create a new instance, but pass the initial buffers to the constructor.
+  pub fn with_buffers(page_size: usize, buffers: Vec<Vec<u8>>) -> Self {
+    RandomAccessMemory {
+      page_size,
+      buffers,
+      length: 0,
+    }
+  }
+}
+
+impl RandomAccess for RandomAccessMemory {
+  type Error = Error;
 
   fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), Self::Error> {
     let new_len = offset + data.len();
@@ -172,6 +155,15 @@ impl RandomAccessMethods for RandomAccessMemoryMethods {
     }
 
     Ok(res_buf)
+  }
+
+  fn read_to_writer(
+    &mut self,
+    _offset: usize,
+    _length: usize,
+    _buf: &mut impl io::Write,
+  ) -> Result<(), Self::Error> {
+    unimplemented!()
   }
 
   fn del(&mut self, offset: usize, length: usize) -> Result<(), Self::Error> {

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,9 +1,11 @@
 #[macro_use]
 extern crate quickcheck;
 extern crate random_access_memory as ram;
+extern crate random_access_storage;
 
 use self::Op::*;
 use quickcheck::{Arbitrary, Gen};
+use random_access_storage::RandomAccess;
 use std::u8;
 
 const MAX_FILE_SIZE: usize = 5 * 10; // 5mb

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,4 +1,7 @@
 extern crate random_access_memory as ram;
+extern crate random_access_storage;
+
+use random_access_storage::RandomAccess;
 
 #[test]
 // Postmortem: looks like we were reading out of bounds by accidentally
@@ -7,7 +10,6 @@ fn regress_1() {
   let mut file = ram::RandomAccessMemory::new(50);
   file.write(30, &[30]).unwrap();
   file.read(15, 15).unwrap();
-  assert!(file.opened);
 }
 
 #[test]
@@ -18,13 +20,11 @@ fn regress_2() {
   file.write(22, &[22, 22, 22, 22]).unwrap();
   let buf = file.read(1, 4).unwrap();
   assert_eq!(buf, vec![0, 0, 0, 0]);
-  assert!(file.opened);
 
   let mut file = ram::RandomAccessMemory::new(50);
   file.write(48, &[48, 48, 48, 48]).unwrap();
   let buf = file.read(39, 9).unwrap();
   assert_eq!(buf, vec![0, 0, 0, 0, 0, 0, 0, 0, 0]);
-  assert!(file.opened);
 }
 
 #[test]
@@ -36,7 +36,6 @@ fn regress_3() {
   file.write(45, &[56, 46, 14, 93, 15, 54, 2]).unwrap();
   let buf = file.read(42, 10).unwrap();
   assert_eq!(buf, vec![0, 0, 0, 56, 46, 14, 93, 15, 54, 2]);
-  assert!(file.opened);
 }
 
 #[test]
@@ -47,5 +46,4 @@ fn regress_4() {
   let mut file = ram::RandomAccessMemory::new(10);
   file.write(44, &[54, 59]).unwrap();
   file.read(13, 3).unwrap();
-  assert!(file.opened);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,7 @@
 extern crate random_access_memory as ram;
+extern crate random_access_storage;
+
+use random_access_storage::RandomAccess;
 
 #[test]
 fn can_call_new() {
@@ -9,7 +12,6 @@ fn can_call_new() {
 fn can_open_buffer() {
   let mut file = ram::RandomAccessMemory::default();
   file.write(0, b"hello").unwrap();
-  assert!(file.opened);
 }
 
 #[test]


### PR DESCRIPTION
Upgrade random-access-storage.

Note that `read_to_writer()` is not implemented because it's not related to this PR, but it was necessary to include the unimplemented method to make it compile.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
Depends on datrs/random-access-storage#11

## Semver Changes
Minor
