### PR TITLE
Update random-access-storage to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 failure = "0.1.1"
-random-access-storage = "0.6.0"
+random-access-storage = "2.0.0"
 
 [dev-dependencies]
 quickcheck = "0.8.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,4 +188,16 @@ impl RandomAccess for RandomAccessMemory {
 
     Ok(())
   }
+
+  fn truncate(&mut self, _length: usize) -> Result<(), Self::Error> {
+    unimplemented!()
+  }
+
+  fn len(&mut self) -> Result<usize, Self::Error> {
+    Ok(self.length)
+  }
+
+  fn is_empty(&mut self) -> Result<bool, Self::Error> {
+    Ok(self.length == 0)
+  }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,3 +30,21 @@ fn can_read() {
   let text = String::from_utf8(text.to_vec()).unwrap();
   assert_eq!(text, "hello world");
 }
+
+#[test]
+fn can_len() {
+  let mut file = ram::RandomAccessMemory::default();
+  assert_eq!(file.len().unwrap(), 0);
+  file.write(0, b"hello").unwrap();
+  assert_eq!(file.len().unwrap(), 5);
+  file.write(5, b" world").unwrap();
+  assert_eq!(file.len().unwrap(), 11);
+}
+
+#[test]
+fn can_is_empty() {
+  let mut file = ram::RandomAccessMemory::default();
+  assert_eq!(file.is_empty().unwrap(), true);
+  file.write(0, b"hello").unwrap();
+  assert_eq!(file.is_empty().unwrap(), false);
+}


### PR DESCRIPTION
~*Submitting this pull request because I need some help resolving an issue*~ Update: resolved.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

This pull request is in regards to work on this issue to update `usize` to `u64`: https://github.com/datrs/random-access-storage/issues/6

As this package would need to update to the upcoming `3.0.0` of `random-access-storage`, I'm attempting to first update to `2.0.0`, which requires adding a handful of additional methods to the `RandomAccess` trait.

I've added `len` a `is_empty`, but `truncate` is troublesome. I assumed that I could make this implementation `del(0, length)`, but this throws an error when the `offset` provided to `del` is zero. I'm unsure if this is a bug in `del`, or if I need to provide a more complex implementation of `truncate`.

```
thread 'can_truncate_lt' panicked at 'attempt to subtract with overflow', src/lib.rs:180:19
```

I've added failing tests for `truncate` based on the tests in [`random-access-disk`](https://github.com/datrs/random-access-disk/blob/f9b34735e79020ff2f39bef510026f5cf8bf02b3/tests/test.rs#L52-L119).

`dependabot` attempted to make this change previously in this pull request: https://github.com/datrs/random-access-memory/pull/9

## Semver Changes
<!-- Which semantic version change would you recommend? -->

This would likely be a minor version change, as additional functionality is added, while existing functionality is unchanged.