### PR TITLE
Update random-access-storage to 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ rust:
   - nightly
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup update stable &&
+  rustup component add --toolchain stable rustfmt-preview &&
+  rustup component add --toolchain stable clippy-preview
 script: |
   cargo check --all-targets --verbose &&
-  cargo fmt -- --check &&
-  cargo clippy -- -D clippy::all &&
+  cargo +stable fmt -- --check &&
+  cargo +stable clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ authors = ["datrs <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-failure = "0.1.1"
-random-access-storage = "2.0.0"
+failure = "0.1.5"
+random-access-storage = "3.0.0"
 
 [dev-dependencies]
-quickcheck = "0.8.1"
-rand = "0.6.0"
+quickcheck = "0.8.5"
+rand = "0.6.5"

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -10,23 +10,23 @@ use rand::Rng;
 use random_access_storage::RandomAccess;
 use std::u8;
 
-const MAX_FILE_SIZE: usize = 5 * 10; // 5mb
+const MAX_FILE_SIZE: u64 = 5 * 10; // 5mb
 
 #[derive(Clone, Debug)]
 enum Op {
-  Read { offset: usize, length: usize },
-  Write { offset: usize, data: Vec<u8> },
+  Read { offset: u64, length: u64 },
+  Write { offset: u64, data: Vec<u8> },
 }
 
 impl Arbitrary for Op {
   fn arbitrary<G: Gen>(g: &mut G) -> Self {
-    let offset: usize = g.gen_range(0, MAX_FILE_SIZE);
-    let length: usize = g.gen_range(0, MAX_FILE_SIZE / 3);
+    let offset: u64 = g.gen_range(0, MAX_FILE_SIZE);
+    let length: u64 = g.gen_range(0, MAX_FILE_SIZE / 3);
 
     if g.gen::<bool>() {
       Read { offset, length }
     } else {
-      let mut data = Vec::with_capacity(length);
+      let mut data = Vec::with_capacity(length as usize);
       for _ in 0..length {
         data.push(u8::arbitrary(g));
       }
@@ -44,22 +44,22 @@ quickcheck! {
       match op {
         Read { offset, length } => {
           let end = offset + length;
-          if model.len() >= end {
+          if model.len() >= end as usize {
             assert_eq!(
               &*implementation.read(offset, length).expect("Reads should be successful."),
-              &model[offset..end]
+              &model[offset as usize..end as usize]
             );
           } else {
             assert!(implementation.read(offset, length).is_err());
           }
         },
         Write { offset, ref data } => {
-          let end = offset + data.len();
-          if model.len() < end {
-            model.resize(end, 0);
+          let end = offset + data.len() as u64;
+          if model.len() < end as usize {
+            model.resize(end as usize, 0);
           }
           implementation.write(offset, &*data).expect("Writes should be successful.");
-          model[offset..end].copy_from_slice(data);
+          model[offset as usize..end as usize].copy_from_slice(data);
         },
       }
     }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** 🐛 + 🙋 

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
This bumps `random-access-storage` to 3.0.0, and fixes compilation
errors necessary on the process.

This commit implements `sync_all` using `Ok(())` as suggested on the PR
introducing the method as I've understood we are using `Vec` and they
are not buffered.

Related to https://github.com/datrs/random-access-storage/issues/6
Related to https://github.com/datrs/random-access-storage/pull/18
Related to https://github.com/datrs/random-access-storage/pull/17
Closes https://github.com/datrs/random-access-memory/pull/14

## Semver Changes
Major bump, as signatures have changed
<!-- Which semantic version change would you recommend? -->
