### PR TITLE
Feat: del() and truncate() using Intmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.26"
 random-access-storage = "4.0.0"
 futures = "0.3.4"
 async-trait = "0.1.24"
+intmap = "2.0.0"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.26"
-random-access-storage = "4.0.0"
+random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "v10"}
 futures = "0.3.4"
 async-trait = "0.1.24"
 intmap = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl RandomAccess for RandomAccessMemory {
     Ok(())
   }
 
-  async fn len(&self) -> Result<u64, Self::Error> {
+  async fn len(&mut self) -> Result<u64, Self::Error> {
     Ok(self.length)
   }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,3 +46,94 @@ async fn can_is_empty() {
   file.write(0, b"hello").await.unwrap();
   assert_eq!(file.is_empty().await.unwrap(), false);
 }
+
+#[async_std::test]
+async fn can_delete() {
+  assert_delete(100).await;
+  assert_delete(10).await;
+  assert_delete(5).await;
+  assert_delete(2).await;
+  assert_delete(1).await;
+}
+
+async fn assert_delete(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.del(6, 2).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  let text = file.read(0, 6).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello ");
+  let zeros = file.read(6, 2).await.unwrap();
+  assert_eq!(zeros, [0, 0]);
+  let text = file.read(8, 10).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "rld people");
+  file.del(8, 4).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+}
+
+#[async_std::test]
+async fn can_truncate_lt() {
+  assert_truncate_lt(100).await;
+  assert_truncate_lt(10).await;
+  assert_truncate_lt(5).await;
+  assert_truncate_lt(2).await;
+  assert_truncate_lt(1).await;
+}
+
+async fn assert_truncate_lt(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(7).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 7);
+  let text = file.read(0, 7).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello w");
+  match file.read(0, 8).await {
+    Ok(_) => panic!("storage is too big. read past the end should have failed"),
+    _ => {}
+  };
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  let zeros = file.read(7, 4).await.unwrap();
+  assert_eq!(zeros, [0, 0, 0, 0]);
+}
+
+#[async_std::test]
+async fn can_truncate_gt() {
+  assert_truncate_gt(100).await;
+  assert_truncate_gt(10).await;
+  assert_truncate_gt(5).await;
+  assert_truncate_gt(2).await;
+  assert_truncate_gt(1).await;
+}
+
+async fn assert_truncate_gt(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(22).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 22);
+  let zeros = file.read(18, 4).await.unwrap();
+  assert_eq!(zeros, [0, 0, 0, 0]);
+  file.write(19, &[1]).await.unwrap();
+  let written = file.read(18, 4).await.unwrap();
+  assert_eq!(written, [0, 1, 0, 0]);
+}
+
+#[async_std::test]
+async fn assert_truncate_eq() {
+  let mut file = ram::RandomAccessMemory::new(5);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(18).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+}


### PR DESCRIPTION
Implements `del()` and `truncate()` with the intmap crate. The existing del() implementation could not work because `Vec<Vec<u8>>` can't handle sparse memory areas.

Also, relies on new random-access-storage with `&mut` fix in `len()`.

NB: The existing, untested `del()` implementation did not seem to actually work at all. My guess is that the implementation was started, but then ran into problems with `Vec<Vec<u8>>` and the implementation was stopped mid way, but the code was not deleted.

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🙋

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
Also fixes missing &mut issue here: https://github.com/datrs/random-access-storage/pull/25. Will be draft until that is merged and can be relied on.

## Semver Changes
If random-access-storage gets a major version bump, this probably should follow even though these are new features.