### PR TITLE
del() and truncate() using Intmap, support RAS 5.0.0, clippy & documentation 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.26"
 random-access-storage = "4.0.0"
 futures = "0.3.4"
 async-trait = "0.1.24"
+intmap = "2.0.0"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ async-trait = "0.1.63"
 intmap = "2.0.0"
 
 [dev-dependencies]
-quickcheck = "0.9.2"
-rand = "0.7.3"
+proptest = "1.1.0"
+proptest-derive = "0.2.0"
 async-std = { version = "1.12.0", features = ["attributes"] }
 criterion = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.26"
-random-access-storage = "4.0.0"
+random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "v10"}
 futures = "0.3.4"
 async-trait = "0.1.24"
 intmap = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.26"
-random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "v10"}
-futures = "0.3.4"
-async-trait = "0.1.24"
+random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "tokio"}
+async-trait = "0.1.63"
 intmap = "2.0.0"
 
 [dev-dependencies]
 quickcheck = "0.9.2"
 rand = "0.7.3"
-async-std = { version = "1.5.0", features = ["attributes"] }
+async-std = { version = "1.12.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "thiserror"}
-async-trait = "0.1.63"
+random-access-storage = "5.0.0"
+async-trait = "0.1"
 intmap = "2.0.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "random-access-memory"
-version = "2.0.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/random-access-memory"
 documentation = "https://docs.rs/random-access-memory"
-description = "Continuously read,write to memory using random offsets and lengths"
-authors = ["datrs <yoshuawuyts@gmail.com>"]
+description = "Continuously read and write to memory using random offsets and lengths"
+authors = ["datrs <yoshuawuyts@gmail.com>", "Timo Tiuraniemi <timo.tiuraniemi@iki.fi>"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "thiserror"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "random-access-memory"
-version = "3.0.0"
+version = "3.0.0-beta.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/datrs/random-access-memory"
 documentation = "https://docs.rs/random-access-memory"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ intmap = "2.0.0"
 quickcheck = "0.9.2"
 rand = "0.7.3"
 async-std = { version = "1.12.0", features = ["attributes"] }
+criterion = "0.4"
+
+[[bench]]
+name = "sync"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.26"
-random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "tokio"}
+random-access-storage = { git = "https://github.com/ttiurani/random-access-storage" , branch = "thiserror"}
 async-trait = "0.1.63"
 intmap = "2.0.0"
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,17 @@
 [![crates.io version][1]][2] [![build status][3]][4]
 [![downloads][5]][6] [![docs.rs docs][7]][8]
 
-Continuously read,write to memory using random offsets and lengths.
+Continuously read and write to memory using random offsets and lengths
+using abstract interface defined in
+[random-access-storage](https://github.com/datrs/random-access-storage).
 
 - [Documentation][8]
 - [Crate][2]
-
-## Usage
-```rust
-use random_access_memory as ram;
-
-let mut file = ram::Sync::default();
-file.write(0, b"hello").await.unwrap();
-file.write(5, b" world").await.unwrap();
-let text = file.read(0, 11).await.unwrap();
-assert_eq!(text, b"hello world");
-```
 
 ## Installation
 ```sh
 $ cargo add random-access-memory
 ```
-
-## Tasks
-- [x] Sync implementation.
-- [ ] Async implementation (wait for futures 1.0.0).
 
 ## License
 [MIT](./LICENSE-MIT) OR [Apache-2.0](./LICENSE-APACHE)

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use random_access_memory as ram;
 use random_access_storage::RandomAccess;
 

--- a/benches/sync.rs
+++ b/benches/sync.rs
@@ -1,25 +1,21 @@
-#![feature(test)]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use random_access_memory as ram;
+use random_access_storage::RandomAccess;
 
-mod sync {
-  extern crate test;
-
-  use random_access_memory as ram;
-  use random_access_storage::RandomAccess;
-  use test::Bencher;
-
-  #[bench]
-  fn write_hello_world(b: &mut Bencher) {
+fn write_hello_world(c: &mut Criterion) {
+  c.bench_function("write hello world", |b| {
     b.iter(|| {
       async_std::task::block_on(async {
         let mut file = ram::RandomAccessMemory::default();
         file.write(0, b"hello").await.unwrap();
         file.write(5, b" world").await.unwrap();
       })
-    });
-  }
+    })
+  });
+}
 
-  #[bench]
-  fn read_hello_world(b: &mut Bencher) {
+fn read_hello_world(c: &mut Criterion) {
+  c.bench_function("read hello world", |b| {
     async_std::task::block_on(async {
       let mut file = ram::RandomAccessMemory::default();
       file.write(0, b"hello").await.unwrap();
@@ -29,11 +25,12 @@ mod sync {
           let _text = file.read(0, 11).await.unwrap();
         })
       });
-    });
-  }
+    })
+  });
+}
 
-  #[bench]
-  fn read_write_hello_world(b: &mut Bencher) {
+fn read_write_hello_world(c: &mut Criterion) {
+  c.bench_function("read/write hello world", |b| {
     b.iter(|| {
       async_std::task::block_on(async {
         let mut file = ram::RandomAccessMemory::default();
@@ -41,6 +38,28 @@ mod sync {
         file.write(5, b" world").await.unwrap();
         let _text = file.read(0, 11).await.unwrap();
       })
-    });
-  }
+    })
+  });
 }
+
+fn write_del_hello_world(c: &mut Criterion) {
+  c.bench_function("write/del hello world", |b| {
+    b.iter(|| {
+      async_std::task::block_on(async {
+        let mut file = ram::RandomAccessMemory::default();
+        file.write(0, b"hello world").await.unwrap();
+        file.del(0, 5).await.unwrap();
+        file.del(5, 6).await.unwrap();
+      })
+    })
+  });
+}
+
+criterion_group!(
+  benches,
+  write_hello_world,
+  read_hello_world,
+  read_write_hello_world,
+  write_del_hello_world,
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl RandomAccess for RandomAccessMemory {
     Ok(())
   }
 
-  async fn len(&self) -> Result<u64, Self::Error> {
+  async fn len(&mut self) -> Result<u64, Self::Error> {
     Ok(self.length)
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,9 +168,9 @@ impl RandomAccess for RandomAccessMemory {
     length: u64,
   ) -> Result<Vec<u8>, RandomAccessError> {
     if (offset + length) > self.length {
-      return Err(RandomAccessError::RangeOutOfBounds {
-        start: offset,
-        end: offset + length,
+      return Err(RandomAccessError::OutOfBounds {
+        offset,
+        end: Some(offset + length),
         length: self.length,
       });
     };
@@ -219,8 +219,9 @@ impl RandomAccess for RandomAccessMemory {
     length: u64,
   ) -> Result<(), RandomAccessError> {
     if offset > self.length {
-      return Err(RandomAccessError::OffsetOutOfBounds {
+      return Err(RandomAccessError::OutOfBounds {
         offset,
+        end: None,
         length: self.length,
       });
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,15 +171,6 @@ impl RandomAccess for RandomAccessMemory {
     Ok(res_buf)
   }
 
-  async fn read_to_writer(
-    &mut self,
-    _offset: u64,
-    _length: u64,
-    _buf: &mut (impl futures::io::AsyncWrite + Send),
-  ) -> Result<(), Self::Error> {
-    unimplemented!()
-  }
-
   async fn del(&mut self, offset: u64, length: u64) -> Result<(), Self::Error> {
     let (first_page_num, first_page_start) =
       self.page_num_and_index(offset, false);

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -19,7 +19,7 @@ impl Arbitrary for Op {
     let offset: u64 = g.gen_range(0, MAX_FILE_SIZE);
     let length: u64 = g.gen_range(0, MAX_FILE_SIZE / 3);
 
-    let op = g.gen_range(0 as u8, 3 as u8);
+    let op = g.gen_range(0_u8, 3_u8);
 
     if op == 0 {
       Read { offset, length }
@@ -59,7 +59,7 @@ quickcheck! {
             if model.len() < end as usize {
               model.resize(end as usize, 0);
             }
-            implementation.write(offset, &*data).await.expect("Writes should be successful.");
+            implementation.write(offset, data).await.expect("Writes should be successful.");
             model[offset as usize..end as usize].copy_from_slice(data);
           },
           Delete { offset, length } => {

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -11,6 +11,7 @@ const MAX_FILE_SIZE: u64 = 5 * 10; // 5mb
 enum Op {
   Read { offset: u64, length: u64 },
   Write { offset: u64, data: Vec<u8> },
+  Delete { offset: u64, length: u64 },
 }
 
 impl Arbitrary for Op {
@@ -18,14 +19,18 @@ impl Arbitrary for Op {
     let offset: u64 = g.gen_range(0, MAX_FILE_SIZE);
     let length: u64 = g.gen_range(0, MAX_FILE_SIZE / 3);
 
-    if g.gen::<bool>() {
+    let op = g.gen_range(0 as u8, 3 as u8);
+
+    if op == 0 {
       Read { offset, length }
-    } else {
+    } else if op == 1 {
       let mut data = Vec::with_capacity(length as usize);
       for _ in 0..length {
         data.push(u8::arbitrary(g));
       }
       Write { offset, data }
+    } else {
+      Delete { offset, length }
     }
   }
 }
@@ -57,6 +62,18 @@ quickcheck! {
             implementation.write(offset, &*data).await.expect("Writes should be successful.");
             model[offset as usize..end as usize].copy_from_slice(data);
           },
+          Delete { offset, length } => {
+            if model.len() >= offset as usize {
+              implementation.del(offset, length).await.expect("Deletes should be successful.");
+              if offset + length < model.len() as u64 {
+                model[offset as usize..(offset + length) as usize].fill(0);
+              } else {
+                model.resize(offset as usize, 0);
+              };
+            } else {
+              assert!(implementation.del(offset, length).await.is_err());
+            }
+          }
         }
       }
       true

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,3 +46,94 @@ async fn can_is_empty() {
   file.write(0, b"hello").await.unwrap();
   assert_eq!(file.is_empty().await.unwrap(), false);
 }
+
+#[async_std::test]
+async fn can_delete() {
+  assert_delete(100).await;
+  assert_delete(10).await;
+  assert_delete(5).await;
+  assert_delete(2).await;
+  assert_delete(1).await;
+}
+
+async fn assert_delete(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.del(6, 2).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  let text = file.read(0, 6).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello ");
+  let zeros = file.read(6, 2).await.unwrap();
+  assert_eq!(zeros, [0, 0]);
+  let text = file.read(8, 10).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "rld people");
+  file.del(8, 4).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+}
+
+#[async_std::test]
+async fn can_truncate_lt() {
+  assert_truncate_lt(100).await;
+  assert_truncate_lt(10).await;
+  assert_truncate_lt(5).await;
+  assert_truncate_lt(2).await;
+  assert_truncate_lt(1).await;
+}
+
+async fn assert_truncate_lt(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(7).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 7);
+  let text = file.read(0, 7).await.unwrap();
+  assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello w");
+  match file.read(0, 8).await {
+    Ok(_) => panic!("storage is too big. read past the end should have failed"),
+    _ => {}
+  };
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  let zeros = file.read(7, 4).await.unwrap();
+  assert_eq!(zeros, [0, 0, 0, 0]);
+}
+
+#[async_std::test]
+async fn can_truncate_gt() {
+  assert_truncate_gt(100).await;
+  assert_truncate_gt(10).await;
+  assert_truncate_gt(5).await;
+  assert_truncate_gt(2).await;
+  assert_truncate_gt(1).await;
+}
+
+async fn assert_truncate_gt(page_size: usize) {
+  let mut file = ram::RandomAccessMemory::new(page_size);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(22).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 22);
+  let zeros = file.read(18, 4).await.unwrap();
+  assert_eq!(zeros, [0, 0, 0, 0]);
+  file.write(19, &[1]).await.unwrap();
+  let written = file.read(18, 4).await.unwrap();
+  assert_eq!(written, [0, 1, 0, 0]);
+}
+
+#[async_std::test]
+async fn assert_truncate_eq() {
+  let mut file = ram::RandomAccessMemory::new(5);
+  file.write(0, b"hello").await.unwrap();
+  file.write(5, b" world").await.unwrap();
+  file.write(11, b" people").await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+  file.truncate(18).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 18);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -42,9 +42,9 @@ async fn can_len() {
 #[async_std::test]
 async fn can_is_empty() {
   let mut file = ram::RandomAccessMemory::default();
-  assert_eq!(file.is_empty().await.unwrap(), true);
+  assert!(file.is_empty().await.unwrap());
   file.write(0, b"hello").await.unwrap();
-  assert_eq!(file.is_empty().await.unwrap(), false);
+  assert!(!file.is_empty().await.unwrap());
 }
 
 #[async_std::test]
@@ -95,9 +95,8 @@ async fn assert_truncate_lt(page_size: usize) {
   assert_eq!(file.len().await.unwrap(), 7);
   let text = file.read(0, 7).await.unwrap();
   assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "hello w");
-  match file.read(0, 8).await {
-    Ok(_) => panic!("storage is too big. read past the end should have failed"),
-    _ => {}
+  if file.read(0, 8).await.is_ok() {
+    panic!("storage is too big. read past the end should have failed");
   };
   file.write(11, b" people").await.unwrap();
   assert_eq!(file.len().await.unwrap(), 18);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -72,6 +72,8 @@ async fn assert_delete(page_size: usize) {
   assert_eq!(String::from_utf8(text.to_vec()).unwrap(), "rld people");
   file.del(8, 4).await.unwrap();
   assert_eq!(file.len().await.unwrap(), 18);
+  file.del(10, 8).await.unwrap();
+  assert_eq!(file.len().await.unwrap(), 10);
 }
 
 #[async_std::test]


### PR DESCRIPTION
## del() and truncate() using Intmap

Implements del() and truncate() with the intmap crate. The existing del() implementation could not work because Vec<Vec<u8>> can't handle sparse memory areas.

Also, relies on new random-access-storage with &mut fix in len().

NB: The existing, untested del() implementation did not seem to actually work at all. My guess is that the implementation was started, but then ran into problems with Vec<Vec<u8>> and the implementation was stopped mid way, but the code was not deleted.

## &mut to len(), remove (unimplemented) read_to_writer()

These changes add compatible with the upcoming 5.0.0 random-access-storage.

## Bump edition from 2018 to 2021

Because this is a breaking change, this is a good place to also bump the rust edition to the latest.

## Switch from quickcheck to proptest

Switch property testing framework from quickcheck to proptest, which is maintained and supports Windows.

## Fix clippy lints

Clippy now passes on all code.

## Comprehensive documentation

Move (broken) documentation from README to lib.rs and document usage with two examples.

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
https://github.com/datrs/random-access-storage/pull/26

## Semver Changes
3.0.0